### PR TITLE
Workaround: Sleep for 10 min before calling data plane APIs

### DIFF
--- a/control-plane/experiencelab.sh
+++ b/control-plane/experiencelab.sh
@@ -582,6 +582,9 @@ function CreateFirstUser() {
   Verify $5 'CreateFirstUser-ERROR: Argument (DATA_PARTITION) not received'
   Verify $6 'CreateFirstUser-ERROR: Argument (FIRST_USER) not received'
 
+  echo "  Waiting 10 min for the instance to come up"
+  sleep 600
+
   ACCESS_TOKEN=$(curl \
       --request POST \
       --url https://login.microsoftonline.com/${2}/oauth2/token \

--- a/control-plane/experiencelab.sh
+++ b/control-plane/experiencelab.sh
@@ -562,6 +562,9 @@ function CreateDataPlatform() {
                               } \
                             }")
     echo "  Data Platform $1 created"
+
+    echo "  Waiting 10 min for the instance to come up"
+    sleep 600
   else
     echo "  Data Platform $1 already exists"
   fi
@@ -581,9 +584,6 @@ function CreateFirstUser() {
   Verify $4 'CreateFirstUser-ERROR: Argument (CLIENT_SECRET) not received'
   Verify $5 'CreateFirstUser-ERROR: Argument (DATA_PARTITION) not received'
   Verify $6 'CreateFirstUser-ERROR: Argument (FIRST_USER) not received'
-
-  echo "  Waiting 10 min for the instance to come up"
-  sleep 600
 
   ACCESS_TOKEN=$(curl \
       --request POST \


### PR DESCRIPTION
Workaround: APIs are returning 502s after creating the instance. After some time the APIs start to work.